### PR TITLE
Enable multiple [name] replacements in AsyncAlpine.alias(). Fixes #32

### DIFF
--- a/src/core/async-alpine.js
+++ b/src/core/async-alpine.js
@@ -270,7 +270,7 @@ const AsyncAlpine = {
     // at this point alias is enabled and the component doesn't exist
     this.url(
       name,
-      this._alias.replace('[name]', name)
+      this._alias.replaceAll('[name]', name)
     );
   },
 


### PR DESCRIPTION
Replace `replace()` in `_handleAlias()` with `replaceAll()`.