### PR TITLE
Replaced skypack with jsdelivr for tests & fix Playwright

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "async-alpine",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "async-alpine",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@playwright/test": "^1.45.3",
+        "@playwright/test": "^1.60.0",
         "@stylistic/eslint-plugin": "^2.3.0",
         "@types/node": "^22.0.0",
         "alpinejs": "^3.14.1",
@@ -18,7 +18,7 @@
         "http-server": "^14.1.1",
         "husky": "^9.1.1",
         "lint-staged": "^15.2.7",
-        "playwright": "^1.45.3"
+        "playwright": "^1.60.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -558,12 +558,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.45.3",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.3.tgz",
-      "integrity": "sha512-UKF4XsBfy+u3MFWEH44hva1Q8Da28G6RFtR2+5saw+jgAFQV5yYnB1fu68Mz7fO+5GJF3wgwAIs0UelU8TxFrA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.45.3"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1572,6 +1573,21 @@
         }
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -2463,12 +2479,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.45.3",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.3.tgz",
-      "integrity": "sha512-QhVaS+lpluxCaioejDZ95l4Y4jSFCsBvl2UZkpeXlzxmqS+aABr5c82YmfMHrL6x27nvrvykJAFpkzT2eWdJww==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.45.3"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2481,29 +2498,16 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.45.3",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.3.tgz",
-      "integrity": "sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/portfinder": {
@@ -3395,12 +3399,12 @@
       }
     },
     "@playwright/test": {
-      "version": "1.45.3",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.3.tgz",
-      "integrity": "sha512-UKF4XsBfy+u3MFWEH44hva1Q8Da28G6RFtR2+5saw+jgAFQV5yYnB1fu68Mz7fO+5GJF3wgwAIs0UelU8TxFrA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "requires": {
-        "playwright": "1.45.3"
+        "playwright": "1.60.0"
       }
     },
     "@stylistic/eslint-plugin": {
@@ -4130,6 +4134,13 @@
       "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4734,28 +4745,19 @@
       "dev": true
     },
     "playwright": {
-      "version": "1.45.3",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.3.tgz",
-      "integrity": "sha512-QhVaS+lpluxCaioejDZ95l4Y4jSFCsBvl2UZkpeXlzxmqS+aABr5c82YmfMHrL6x27nvrvykJAFpkzT2eWdJww==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.45.3"
-      },
-      "dependencies": {
-        "fsevents": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-          "dev": true,
-          "optional": true
-        }
+        "playwright-core": "1.60.0"
       }
     },
     "playwright-core": {
-      "version": "1.45.3",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.3.tgz",
-      "integrity": "sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true
     },
     "portfinder": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "*": "npm run format"
   },
   "devDependencies": {
-    "@playwright/test": "^1.45.3",
+    "@playwright/test": "^1.60.0",
     "@stylistic/eslint-plugin": "^2.3.0",
     "@types/node": "^22.0.0",
     "alpinejs": "^3.14.1",
@@ -35,7 +35,7 @@
     "http-server": "^14.1.1",
     "husky": "^9.1.1",
     "lint-staged": "^15.2.7",
-    "playwright": "^1.45.3"
+    "playwright": "^1.60.0"
   },
   "scripts": {
     "dev": "node scripts/build.js --watch",

--- a/tests/alpine/bind/index.html
+++ b/tests/alpine/bind/index.html
@@ -27,7 +27,7 @@
   >Shorthand bind</div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
 		Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/alpine/cloak/index.html
+++ b/tests/alpine/cloak/index.html
@@ -25,7 +25,7 @@
   </div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
 		setTimeout(() => {
 			Alpine.plugin(AsyncAlpine)

--- a/tests/alpine/effect/index.html
+++ b/tests/alpine/effect/index.html
@@ -23,7 +23,7 @@
   </div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
 		Alpine.plugin(AsyncAlpine)
 		Alpine.start()

--- a/tests/alpine/for/index.html
+++ b/tests/alpine/for/index.html
@@ -22,7 +22,7 @@
   </div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs'
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js'
     import AsyncAlpine from '/dist/async-alpine.esm.js'
 		Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/alpine/html/index.html
+++ b/tests/alpine/html/index.html
@@ -19,7 +19,7 @@
   </div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs'
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js'
     import AsyncAlpine from '/dist/async-alpine.esm.js'
 		Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/alpine/id/index.html
+++ b/tests/alpine/id/index.html
@@ -31,7 +31,7 @@
   </div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs'
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js'
     import AsyncAlpine from '/dist/async-alpine.esm.js'
 		Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/alpine/if/index.html
+++ b/tests/alpine/if/index.html
@@ -20,7 +20,7 @@
   </div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs'
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js'
     import AsyncAlpine from '/dist/async-alpine.esm.js'
 		Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/alpine/ignore/index.html
+++ b/tests/alpine/ignore/index.html
@@ -26,7 +26,7 @@
   </div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs'
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js'
     import AsyncAlpine from '/dist/async-alpine.esm.js'
 		Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/alpine/model/index.html
+++ b/tests/alpine/model/index.html
@@ -22,7 +22,7 @@
   </div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/alpine/modelable/index.html
+++ b/tests/alpine/modelable/index.html
@@ -22,7 +22,7 @@
   </div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/alpine/morph/index.html
+++ b/tests/alpine/morph/index.html
@@ -21,7 +21,7 @@
   <button data-testid="button">Run morph</button>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs'
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js'
     import AsyncAlpine from '/dist/async-alpine.esm.js'
     import AlpineMorph from 'https://cdn.skypack.dev/@alpinejs/morph'
 		Alpine.plugin(AsyncAlpine)

--- a/tests/alpine/on/index.html
+++ b/tests/alpine/on/index.html
@@ -42,7 +42,7 @@
 	</div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs'
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js'
     import AsyncAlpine from '/dist/async-alpine.esm.js'
 		Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/alpine/ref/index.html
+++ b/tests/alpine/ref/index.html
@@ -19,7 +19,7 @@
   </div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs'
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js'
     import AsyncAlpine from '/dist/async-alpine.esm.js'
 		Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/alpine/show/index.html
+++ b/tests/alpine/show/index.html
@@ -22,7 +22,7 @@
   </div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs'
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js'
     import AsyncAlpine from '/dist/async-alpine.esm.js'
 		Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/alpine/teleport/index.html
+++ b/tests/alpine/teleport/index.html
@@ -26,7 +26,7 @@
 	</div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs'
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js'
     import AsyncAlpine from '/dist/async-alpine.esm.js'
 		Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/alpine/text/index.html
+++ b/tests/alpine/text/index.html
@@ -19,7 +19,7 @@
   </div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs'
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js'
     import AsyncAlpine from '/dist/async-alpine.esm.js'
 		Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/alpine/transition/index.html
+++ b/tests/alpine/transition/index.html
@@ -24,7 +24,7 @@
   </div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs'
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js'
     import AsyncAlpine from '/dist/async-alpine.esm.js'
 		Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/installation/module-crossorigin/index.html
+++ b/tests/installation/module-crossorigin/index.html
@@ -18,7 +18,7 @@
   ></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from 'https://async-alpine-dev.surge.sh/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/installation/module/index.html
+++ b/tests/installation/module/index.html
@@ -17,7 +17,7 @@
   ></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/loading/alias-function/index.html
+++ b/tests/loading/alias-function/index.html
@@ -16,7 +16,7 @@
   ></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.asyncAlias((name) => import(`/tests/assets/${name}.js`))

--- a/tests/loading/alias/index.html
+++ b/tests/loading/alias/index.html
@@ -16,7 +16,7 @@
   ></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.asyncAlias('/tests/assets/[name].js')

--- a/tests/loading/dynamic-function/index.html
+++ b/tests/loading/dynamic-function/index.html
@@ -16,7 +16,7 @@
   ></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.asyncData('output', () => {

--- a/tests/loading/dynamic/index.html
+++ b/tests/loading/dynamic/index.html
@@ -16,7 +16,7 @@
   ></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.asyncData('output', () => import('/tests/assets/output.js'))

--- a/tests/loading/inline-data/index.html
+++ b/tests/loading/inline-data/index.html
@@ -34,7 +34,7 @@
   </div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/loading/inline/index.html
+++ b/tests/loading/inline/index.html
@@ -17,7 +17,7 @@
   ></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/loading/url/index.html
+++ b/tests/loading/url/index.html
@@ -16,7 +16,7 @@
   ></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.asyncUrl('output', '/tests/assets/output.js')

--- a/tests/misc/default-strategy/index.html
+++ b/tests/misc/default-strategy/index.html
@@ -17,7 +17,7 @@
   ></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
 		Alpine.asyncOptions({

--- a/tests/misc/nested/index.html
+++ b/tests/misc/nested/index.html
@@ -24,7 +24,7 @@
   </div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/mutations/body/index.html
+++ b/tests/mutations/body/index.html
@@ -28,7 +28,7 @@
   </button>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/mutations/mutation/index.html
+++ b/tests/mutations/mutation/index.html
@@ -28,7 +28,7 @@
   <div data-testid="result" id="result"></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/mutations/nested/index.html
+++ b/tests/mutations/nested/index.html
@@ -30,7 +30,7 @@
   <div data-testid="result" id="result"></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/strategies/basic-and/index.html
+++ b/tests/strategies/basic-and/index.html
@@ -26,7 +26,7 @@
   ></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/strategies/basic-or/index.html
+++ b/tests/strategies/basic-or/index.html
@@ -30,7 +30,7 @@
   ></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/strategies/complex-combination/index.html
+++ b/tests/strategies/complex-combination/index.html
@@ -61,7 +61,7 @@
   ></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/strategies/eager/index.html
+++ b/tests/strategies/eager/index.html
@@ -24,7 +24,7 @@
   ></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/strategies/event/index.html
+++ b/tests/strategies/event/index.html
@@ -43,7 +43,7 @@
   </div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/strategies/idle/index.html
+++ b/tests/strategies/idle/index.html
@@ -17,7 +17,7 @@
   ></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/strategies/legacy-and/index.html
+++ b/tests/strategies/legacy-and/index.html
@@ -26,7 +26,7 @@
   ></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/strategies/media/index.html
+++ b/tests/strategies/media/index.html
@@ -24,7 +24,7 @@
   ></div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()

--- a/tests/strategies/visible/index.html
+++ b/tests/strategies/visible/index.html
@@ -26,7 +26,7 @@
   >custom rootMargin</div>
 
   <script type="module">
-    import Alpine from 'https://cdn.skypack.dev/alpinejs';
+    import Alpine from 'https://cdn.jsdelivr.net/npm/alpinejs/dist/module.esm.js';
     import AsyncAlpine from '/dist/async-alpine.esm.js';
     Alpine.plugin(AsyncAlpine)
     Alpine.start()


### PR DESCRIPTION
Skypack was serving 403 errors for some networks and jsdelivr seems more reliable.

Also includes an upgrade to Playwright 1.60 to fix test running in CI.